### PR TITLE
remove cmr logic from stack building code

### DIFF
--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -22,14 +22,7 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
     Lambda handler for STAC Collection Item generation
 
     Arguments:
-    event - object with event parameters to be provided in one of 2 formats.
-        Format option 1 (with Granule ID defined to retrieve all metadata from CMR):
-        {
-            "collection": "OMDOAO3e",
-            "remote_fileurl": "s3://climatedashboard-data/OMDOAO3e/OMI-Aura_L3-OMDOAO3e_2022m0120_v003-2022m0122t021759.he5.tif",
-            "granule_id": "G2205784904-GES_DISC",
-        }
-        Format option 2 (with regex provided to parse datetime from the filename:
+    event - object with event parameters.
         {
             "collection": "OMDOAO3e",
             "remote_fileurl": "s3://climatedashboard-data/OMSO2PCA/OMSO2PCA_LUT_SCD_2005.tif",
@@ -37,8 +30,7 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
     """
 
-    EventType = events.CmrEvent if event.get("granule_id") else events.RegexEvent
-    parsed_event = EventType.parse_obj(event)
+    parsed_event = events.RegexEvent.parse_obj(event)
     stac_item = stac.generate_stac(parsed_event).to_dict()
 
     output: StacItemOutput = {"stac_item": stac_item}
@@ -57,17 +49,9 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 if __name__ == "__main__":
     sample_event = {
-        "collection": "GEDI02_A",
-        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/GEDI02_A___002/2020.12.31/GEDI02_A_2020366232302_O11636_02_T08595_02_003_02_V002.h5",
-        "granule_id": "G1201782029-NASA_MAAP",
-        "id": "G1201782029-NASA_MAAP",
-        "mode": "cmr",
-        "test_links": None,
-        "reverse_coords": None,
-        "asset_name": "data",
-        "asset_roles": [
-            "data"
-        ],
-        "asset_media_type": "application/x-hdf5"
-        }
+        "collection": "icesat2-boreal",
+        "remote_fileurl": "s3://maap-user-shared-data/icesat2-boreal/boreal_agb_202302151676439579_1326.tif",
+        "upload": True,
+        "properties": {}
+    }
     print(json.dumps(handler(sample_event, {}), indent=2))

--- a/lambdas/build-stac/tests/test_handler.py
+++ b/lambdas/build-stac/tests/test_handler.py
@@ -65,31 +65,6 @@ def test_routing_regex_event():
     assert not not_called_mock.call_count
 
 
-def test_routing_cmr_event():
-    """
-    Ensure that the system properly identifies, classifies, and routes CMR-style events.
-    """
-    cmr_event = {
-        "collection": "test-collection",
-        "remote_fileurl": "s3://test-bucket/delivery/BMHD_Maria_Stages/70001_BeforeMaria_Stage0_2017-07-21.tif",
-        "granule_id": "test-granule",
-    }
-
-    with override_registry(
-        stac.generate_stac,
-        events.CmrEvent,
-        MagicMock(return_value=build_mock_stac_item({"mock": "STAC Item 1"})),
-    ) as called_mock, override_registry(
-        stac.generate_stac,
-        events.RegexEvent,
-        MagicMock(),
-    ) as not_called_mock:
-        handler.handler(cmr_event, None)
-
-    called_mock.assert_called_once_with(events.CmrEvent.parse_obj(cmr_event))
-    assert not not_called_mock.call_count
-
-
 @pytest.mark.parametrize(
     "bad_event",
     [{"collection": "test-collection"}],

--- a/lambdas/build-stac/utils/events.py
+++ b/lambdas/build-stac/utils/events.py
@@ -32,11 +32,6 @@ class BaseEvent(BaseModel, frozen=True):
             id = Path(self.remote_fileurl).stem
         return id
 
-
-class CmrEvent(BaseEvent):
-    granule_id: str
-
-
 class RegexEvent(BaseEvent):
     filename_regex: Optional[str]
 
@@ -48,4 +43,4 @@ class RegexEvent(BaseEvent):
     datetime_range: Optional[INTERVAL] = None
 
 
-SupportedEvent = Union[RegexEvent, CmrEvent]
+SupportedEvent = Union[RegexEvent]

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -1,15 +1,10 @@
 import os
-import json
-import geojson
 from pathlib import Path
-import requests
 from functools import singledispatch
 
 import pystac
 import rasterio
 
-from cmr import GranuleQuery
-from pystac.utils import str_to_datetime
 from rio_stac import stac
 from rasterio.session import AWSSession
 
@@ -135,139 +130,4 @@ def generate_stac_regexevent(item: events.RegexEvent) -> pystac.Item:
         asset_name=item.asset_name,
         asset_roles=item.asset_roles,
         asset_media_type=item.asset_media_type,
-    )
-
-
-def pairwise(iterable) -> zip:
-    """
-    generates a generator object of tuples from a flat list
-    "[s0, s1, s2, s3, s4, s5, ...] -> [(s0, s1), (s2, s3), (s4, s5), ...]"
-    """
-    a = iter(iterable)
-    return zip(a, a)
-
-def get_bbox(coord_list) -> list[float]:
-    """
-    Returns the corners of a list of coordinates by:
-    1. Sorting the coordinates by latitude and longitude coordinates
-    2. Adding the min and max value for latitude and min and max value for longitude to a list
-    3. Returning a list of min x, min y, max x, max y
-    """
-    box = []
-    for i in (0,1):
-        res = sorted(coord_list, key=lambda x:x[i])
-        box.append((res[0][i], res[-1][i]))
-    ret = [box[0][0], box[1][0], box[0][1], box[1][1]]
-    return ret
-
-def generate_geometry_from_cmr(cmr_json, item) -> dict:
-    """
-    Generates geoJSON object from list of coordinates provided in CMR JSON
-    """
-    str_coords = None
-    if cmr_json.get('polygons'):
-        str_coords = cmr_json['polygons'][0][0].split()
-        if item.reverse_coords:
-            str_coords.reverse()
-    elif cmr_json.get("boxes"):
-        str_coords = cmr_json['boxes'][0].split()
-
-    if str_coords:
-        polygon_coords = [(float(x), float(y)) for x,y in pairwise(str_coords)]
-        if len(polygon_coords) == 2:
-            polygon_coords.insert(1, (polygon_coords[1][0], polygon_coords[0][1]))
-            polygon_coords.insert(3, (polygon_coords[0][0], polygon_coords[2][1]))
-            polygon_coords.insert(4, polygon_coords[0])
-        return {
-            "coordinates": [polygon_coords],
-            "type": "Polygon"
-        }
-    else:
-        return None
-
-def gen_asset(role: str, link: dict, item: dict) -> pystac.Asset:
-    if item.test_links and 'http' in link.get('href'):
-        try:
-            requests.head(link.get('href'))
-        except Exception as e:
-            print(f"Caught error for link {link}: {e}")
-            return None
-    asset_media_type = link.get('type')
-    # Fallback to asset_media_type defined in the item
-    if asset_media_type == None and role == 'data':
-        asset_media_type = item.asset_media_type
-
-    if role == 'data' and 's3://' not in link.get('href'):
-        pass
-    else:
-        return pystac.Asset(
-            roles=[role],
-            href=link.get('href'),
-            media_type=asset_media_type
-        )
-
-def get_assets_from_cmr(cmr_json, item) -> dict[pystac.Asset]:
-    """
-    Generates a dictionary of pystac.Asset's from cmr_json links
-    TODO(aimee): This is using some heuristics and could probably be refined according to some standard in the future.
-    """
-    assets = {}
-    links = cmr_json['links']
-    for link in links:
-        if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/data#":
-            extension = os.path.splitext(link['href'])[-1].replace('.', '')
-            if extension == 'prj':
-                role = 'metadata'
-                asset = gen_asset('metadata', link, item)
-                if asset:
-                    assets['metadata'] = asset
-            asset = gen_asset('data', link, item)
-            if asset:
-                assets['data'] = asset
-        if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/s3#":
-            asset = gen_asset('data', link, item)
-            if asset:
-                assets['data'] = asset
-        if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/metadata#" and 'metadata' not in assets:
-            asset = gen_asset('metadata', link, item)
-            if asset:
-                assets['metadata'] = asset
-        if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/documentation#" and 'documentation' not in assets:
-            asset = gen_asset('documentation', link, item)
-            if asset:
-                assets['documentation'] = asset
-    return assets
-
-def cmr_api_url() -> str:
-    default_cmr_api_url = "https://cmr.earthdata.nasa.gov"
-    cmr_api_url = os.environ.get('CMR_API_URL', default_cmr_api_url)
-    return cmr_api_url
-
-@generate_stac.register
-def generate_stac_cmrevent(item: events.CmrEvent) -> pystac.Item:
-    """
-    Generate STAC Item from CMR granule
-    """
-    cmr_json = GranuleQuery(mode=f"{cmr_api_url()}/search/").concept_id(item.granule_id).get(1)[0]
-    cmr_json['concept_id'] = cmr_json.pop('id')
-    geometry = generate_geometry_from_cmr(cmr_json, item)
-    if geometry:
-        bbox = get_bbox(list(geojson.utils.coords(geometry['coordinates'])))
-    else:
-        bbox = None
-    assets = get_assets_from_cmr(cmr_json, item)
-
-    return create_item(
-        id=item.item_id(),
-        properties=cmr_json,
-        mode=item.mode,
-        datetime=str_to_datetime(cmr_json["time_start"]),
-        item_url=item.remote_fileurl,
-        collection=item.collection,
-        asset_name=item.asset_name,
-        asset_roles=item.asset_roles,
-        asset_media_type=item.asset_media_type,
-        assets=assets,
-        bbox=bbox,
-        geometry=geometry
     )


### PR DESCRIPTION
This completes the first of the three (new) tasks of this ticket https://github.com/NASA-IMPACT/active-maap-sprint/issues/442, which is to remove the CMR logic from the build stack code. 

In addition, it replaces the hard coded event example at the bottom of `handler.py` with an S3 COG example. Setting up the environment and running `python handler.py` works with this PR. Note that the tests were already failing before this PR, and should be fixed from a separate ticket I think ?