### PR TITLE
Do accept links to files w/o s3 prefix

### DIFF
--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -196,13 +196,10 @@ def gen_asset(role: str, link: dict, item: dict) -> pystac.Asset:
     # Fallback to asset_media_type defined in the item
     if asset_media_type == None and role == "data":
         asset_media_type = item.asset_media_type
-
-    if role == "data" and "s3://" not in link.get("href"):
-        pass
-    else:
-        return pystac.Asset(
-            roles=[role], href=link.get("href"), media_type=asset_media_type
-        )
+        
+    return pystac.Asset(
+        roles=[role], href=link.get("href"), media_type=asset_media_type
+    )
 
 
 def get_assets_from_cmr(cmr_json, item) -> dict[pystac.Asset]:

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -217,7 +217,7 @@ def get_assets_from_cmr(cmr_json, item) -> dict[pystac.Asset]:
                 if asset:
                     assets["metadata"] = asset
             asset = gen_asset("data", link, item)
-            if asset and not assets["data"]:
+            if asset and "data" not in assets:
                 assets["data"] = asset
         if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/s3#":
             asset = gen_asset("data", link, item)


### PR DESCRIPTION
lambdas.build_stac.utils.stac.gen_asset ignores a data asset if its link does not have an s3 prefix. We have valid data URLs for ESACCI biomass without s3 prefixes, for example, so I suggest to remove that conditional. In this example again, with that conditional we end up with items with missing data assets.