### PR TITLE
add json files for sentinel1 RTC pilot data

### DIFF
--- a/data/collections/S1_RTC_seasonal_composite.json
+++ b/data/collections/S1_RTC_seasonal_composite.json
@@ -1,0 +1,25 @@
+{
+    "id": "s1-rtc-seasonal-composite",
+    "stac_version": "1.0.0",
+    "license": "not-provided",
+    "title": "Sentinel 1 RTC seasonal mosaic",
+    "type": "Collection",
+    "description": "Sentinel 1 RTC seasonal mosaic. The Sentinel-1 mission is a constellation of two polar-orbiting satellites, operating day and night performing C-band synthetic aperture radar imaging.",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+              -180, 50, 180, 77
+          ]
+      ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2014-01-01T00:00:00.000Z",
+            "2023-01-01T00:00:00.000Z"
+          ]
+        ]
+      }
+    }
+}

--- a/data/step_function_inputs/S1_RTC_seasonal_composite.json
+++ b/data/step_function_inputs/S1_RTC_seasonal_composite.json
@@ -1,0 +1,7 @@
+{
+    "collection": "s1-rtc-seasonal-composite",
+    "discovery": "inventory",
+    "inventory_url": "s3://maap-ops-workspace/shared/nathanmthomas/sentinel1_seasonal_comps/inventory.csv",
+    "cogify": false,
+    "upload": false
+}


### PR DESCRIPTION
This is published to the test STAC catalog : https://stac-browser.test.maap-project.org/collections/s1-rtc-seasonal-composite. 

Several things will likely change once the full dataset is ready to be published. 