### PR TITLE
Update the fork with datetime related commits

### DIFF
--- a/lambdas/build-stac/tests/test_regex.py
+++ b/lambdas/build-stac/tests/test_regex.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from utils import regex, events
 
@@ -11,77 +11,77 @@ from utils import regex, events
         (
             # Single datetime - %Y-%m-%d
             ("s3://foo/bar/foo_2010-10-31_bar.tif", None),
-            (None, None, datetime(2010, 10, 31)),
+            (None, None, datetime(2010, 10, 31).replace(tzinfo=timezone.utc)),
         ),
         (
             # Single datetime - %Y%m%d
             ("s3://foo/bar/foo_20051212_bar.tif", None),
-            (None, None, datetime(2005, 12, 12)),
+            (None, None, datetime(2005, 12, 12).replace(tzinfo=timezone.utc)),
         ),
         (
             # Single datetime - %Y%m
             ("s3://foo/bar/foo_200507_bar.tif", None),
-            (None, None, datetime(2005, 7, 1)),
+            (None, None, datetime(2005, 7, 1).replace(tzinfo=timezone.utc)),
         ),
         (
             # Single datetime - %Y
             ("s3://foo/bar/foo_2012_bar.tif", None),
-            (None, None, datetime(2012, 1, 1)),
+            (None, None, datetime(2012, 1, 1).replace(tzinfo=timezone.utc)),
         ),
         (
             # Daterange - %Y-%m-%d
             ("s3://foo/bar/foo_2005-07-02_to_2006-09-29_bar.tif", None),
-            (datetime(2005, 7, 2), datetime(2006, 9, 29), None),
+            (datetime(2005, 7, 2).replace(tzinfo=timezone.utc), datetime(2006, 9, 29).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Daterange - %Y%m%d
             ("s3://foo/bar/foo_20050702_to_20060929_bar.tif", None),
-            (datetime(2005, 7, 2), datetime(2006, 9, 29), None),
+            (datetime(2005, 7, 2).replace(tzinfo=timezone.utc), datetime(2006, 9, 29).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Daterange - %Y
             ("s3://foo/bar/foo_2005_2006_2007_bar.tif", None),
-            (datetime(2005, 1, 1), datetime(2007, 1, 1), None),
+            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2007, 1, 1).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to month range - %Y-%m-%d
             ("s3://foo/bar/foo_2005-01-02.tif", "month"),
-            (datetime(2005, 1, 1), datetime(2005, 1, 31), None),
+            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 1, 31).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to month range - %Y%m%d
             ("s3://foo/bar/foo_2005-02-02.tif", "month"),
-            (datetime(2005, 2, 1), datetime(2005, 2, 28), None),
+            (datetime(2005, 2, 1).replace(tzinfo=timezone.utc), datetime(2005, 2, 28).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to month range - %Y%m
             ("s3://foo/bar/foo_20050302_bar.tif", "month"),
-            (datetime(2005, 3, 1), datetime(2005, 3, 31), None),
+            (datetime(2005, 3, 1).replace(tzinfo=timezone.utc), datetime(2005, 3, 31).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to month range - %Y
             ("s3://foo/bar/foo_20050402_bar.tif", "month"),
-            (datetime(2005, 4, 1), datetime(2005, 4, 30), None),
+            (datetime(2005, 4, 1).replace(tzinfo=timezone.utc), datetime(2005, 4, 30).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to year range - %Y-%m-%d
             ("s3://foo/bar/foo_2005-01-02.tif", "year"),
-            (datetime(2005, 1, 1), datetime(2005, 12, 31), None),
+            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to year range - %Y%m%d
             ("s3://foo/bar/foo_2005-02-02.tif", "year"),
-            (datetime(2005, 1, 1), datetime(2005, 12, 31), None),
+            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to year range - %Y%m
             ("s3://foo/bar/foo_20050302_bar.tif", "year"),
-            (datetime(2005, 1, 1), datetime(2005, 12, 31), None),
+            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
         ),
         (
             # Single date converted to year range - %Y
             ("s3://foo/bar/foo_20050402_bar.tif", "year"),
-            (datetime(2005, 1, 1), datetime(2005, 12, 31), None),
+            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
         ),
     ],
 )

--- a/lambdas/build-stac/tests/test_regex.py
+++ b/lambdas/build-stac/tests/test_regex.py
@@ -31,57 +31,101 @@ from utils import regex, events
         (
             # Daterange - %Y-%m-%d
             ("s3://foo/bar/foo_2005-07-02_to_2006-09-29_bar.tif", None),
-            (datetime(2005, 7, 2).replace(tzinfo=timezone.utc), datetime(2006, 9, 29).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 7, 2).replace(tzinfo=timezone.utc),
+                datetime(2006, 9, 29).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Daterange - %Y%m%d
             ("s3://foo/bar/foo_20050702_to_20060929_bar.tif", None),
-            (datetime(2005, 7, 2).replace(tzinfo=timezone.utc), datetime(2006, 9, 29).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 7, 2).replace(tzinfo=timezone.utc),
+                datetime(2006, 9, 29).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Daterange - %Y
             ("s3://foo/bar/foo_2005_2006_2007_bar.tif", None),
-            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2007, 1, 1).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 1, 1).replace(tzinfo=timezone.utc),
+                datetime(2007, 1, 1).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to month range - %Y-%m-%d
             ("s3://foo/bar/foo_2005-01-02.tif", "month"),
-            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 1, 31).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 1, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 1, 31).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to month range - %Y%m%d
             ("s3://foo/bar/foo_2005-02-02.tif", "month"),
-            (datetime(2005, 2, 1).replace(tzinfo=timezone.utc), datetime(2005, 2, 28).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 2, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 2, 28).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to month range - %Y%m
             ("s3://foo/bar/foo_20050302_bar.tif", "month"),
-            (datetime(2005, 3, 1).replace(tzinfo=timezone.utc), datetime(2005, 3, 31).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 3, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 3, 31).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to month range - %Y
             ("s3://foo/bar/foo_20050402_bar.tif", "month"),
-            (datetime(2005, 4, 1).replace(tzinfo=timezone.utc), datetime(2005, 4, 30).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 4, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 4, 30).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to year range - %Y-%m-%d
             ("s3://foo/bar/foo_2005-01-02.tif", "year"),
-            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 1, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 12, 31).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to year range - %Y%m%d
             ("s3://foo/bar/foo_2005-02-02.tif", "year"),
-            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 1, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 12, 31).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to year range - %Y%m
             ("s3://foo/bar/foo_20050302_bar.tif", "year"),
-            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 1, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 12, 31).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
         (
             # Single date converted to year range - %Y
             ("s3://foo/bar/foo_20050402_bar.tif", "year"),
-            (datetime(2005, 1, 1).replace(tzinfo=timezone.utc), datetime(2005, 12, 31).replace(tzinfo=timezone.utc), None),
+            (
+                datetime(2005, 1, 1).replace(tzinfo=timezone.utc),
+                datetime(2005, 12, 31).replace(tzinfo=timezone.utc),
+                None,
+            ),
         ),
     ],
 )

--- a/lambdas/build-stac/utils/regex.py
+++ b/lambdas/build-stac/utils/regex.py
@@ -1,6 +1,6 @@
 import re
 from typing import Callable, Dict, Tuple, Union
-from datetime import datetime
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 
 from . import events
@@ -48,7 +48,9 @@ def extract_dates(
             continue
 
         for date_str in dates_found:
-            dates.append(datetime.strptime(date_str, dateformat))
+            date = datetime.strptime(date_str, dateformat)
+            date_tz = date.replace(tzinfo=timezone.utc)
+            dates.append(date_tz)
 
         break
 

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -122,8 +122,9 @@ def generate_stac_regexevent(item: events.RegexEvent) -> pystac.Item:
         )
     properties = item.properties or {}
     if start_datetime and end_datetime:
-        properties["start_datetime"] = start_datetime.isoformat()
-        properties["end_datetime"] = end_datetime.isoformat()
+        # these are added post-serialization to properties, unlike single_datetime
+        properties["start_datetime"] = start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+        properties["end_datetime"] = end_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
         single_datetime = None
 
     return create_item(


### PR DESCRIPTION
Links to https://github.com/NASA-IMPACT/active-maap-sprint/issues/441/ 

I attempted to do a full update here https://github.com/MAAP-Project/veda-data-pipelines/pull/11 but I am encountering issues so I am focusing only on the datetime commits for now, in order to solve https://github.com/NASA-IMPACT/active-maap-sprint/issues/423.

I deployed this to the test stac. That being said, I don't feel like the problem described in  https://github.com/NASA-IMPACT/active-maap-sprint/issues/423 is solved. Taking the example of the ticket, the temporal extent still doesn't have the 'right' format : https://stac.test.maap-project.org/collections/AfriSAR_UAVSAR_Coreg_SLC. 

However, I don't see how the upstream commits would solve that, since they affect only the item records themselves, and not the collection record. In addition, these commits do not affect the ingestion from the CMR (only affects `lamb das.build_stac.generate_stac_regexevent`).

Thoughts @jjfrench ?

