### PR TITLE
Integrate NISAR stactools package

### DIFF
--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -2,7 +2,7 @@ import json
 import os
 import importlib
 import subprocess
-import sys 
+import sys
 from typing import Any, Dict, TypedDict, Union
 from uuid import uuid4
 
@@ -10,7 +10,10 @@ import smart_open
 
 from utils import stac, events
 
-AVAILABLE_STACTOOLS_MODULES = ["nisar_sim"] # update requirements.txt if this is updated.
+AVAILABLE_STACTOOLS_MODULES = [
+    "nisar_sim"
+]  # update requirements.txt if this is updated.
+
 
 class S3LinkOutput(TypedDict):
     stac_file_url: str
@@ -37,14 +40,14 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
             "collection": "OMDOAO3e",
             "remote_fileurl": "s3://climatedashboard-data/OMSO2PCA/OMSO2PCA_LUT_SCD_2005.tif",
         }
-        Format option 3 (with stactools package) where stactools-module represents the module of the stactools package to use. The package must comply with https://github.com/stactools-packages/template and be installed in the instance executing this code. 
+        Format option 3 (with stactools package) where stactools-module represents the module of the stactools package to use. The package must comply with https://github.com/stactools-packages/template and be installed in the instance executing this code.
         {
             "collection" : "NISAR",
             "stactools-module": "<stactools-module",
             " ... additional keys corresponding to the module's `create_item` method arguments"
         }
 
-        example : 
+        example :
 
         {
             "collection": "NISAR",
@@ -59,7 +62,7 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
     if "stactools-module" in event:
         module_str = event.pop("stactools-module")
         assert module_str in AVAILABLE_STACTOOLS_MODULES
-        stac_module = importlib.import_module(f'stactools.{module_str}.stac')
+        stac_module = importlib.import_module(f"stactools.{module_str}.stac")
         stac_item = stac_module.create_item(event)
     else:
         EventType = events.CmrEvent if event.get("granule_id") else events.RegexEvent
@@ -81,7 +84,6 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 
 if __name__ == "__main__":
-    
     # sample_event = {
     #     "collection": "GEDI02_A",
     #     "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/GEDI02_A___002/2020.12.31/GEDI02_A_2020366232302_O11636_02_T08595_02_003_02_V002.h5",
@@ -98,8 +100,8 @@ if __name__ == "__main__":
     sample_event = {
         "collection": "NISAR",
         "stactools-module": "nisar_sim",
-        "source":"tests/data-files/winnip_31604_12061_004_120717_L090_CX_07",
-        "dither": "X"
+        "source": "tests/data-files/winnip_31604_12061_004_120717_L090_CX_07",
+        "dither": "X",
     }
 
     print(json.dumps(handler(sample_event, {}), indent=2))

--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -56,9 +56,9 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
     """
 
     if "stactools-package" in event:
-        repo_url, module_str = event["stactools-package"].split(":")
+        repo_url, module_str = event.pop("stactools-package").split("::")
         subprocess.run([sys.executable, "-m", "pip", "install", repo_url])
-        stac_module = importlib(module_str)
+        stac_module = importlib.import_module(module_str)
         stac_item = stac_module.create_item(event)
     else:
         EventType = events.CmrEvent if event.get("granule_id") else events.RegexEvent
@@ -80,16 +80,24 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 
 if __name__ == "__main__":
+    # sample_event = {
+    #     "collection": "GEDI02_A",
+    #     "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/GEDI02_A___002/2020.12.31/GEDI02_A_2020366232302_O11636_02_T08595_02_003_02_V002.h5",
+    #     "granule_id": "G1201782029-NASA_MAAP",
+    #     "id": "G1201782029-NASA_MAAP",
+    #     "mode": "cmr",
+    #     "test_links": None,
+    #     "reverse_coords": None,
+    #     "asset_name": "data",
+    #     "asset_roles": ["data"],
+    #     "asset_media_type": "application/x-hdf5",
+    # }
+
     sample_event = {
-        "collection": "GEDI02_A",
-        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/GEDI02_A___002/2020.12.31/GEDI02_A_2020366232302_O11636_02_T08595_02_003_02_V002.h5",
-        "granule_id": "G1201782029-NASA_MAAP",
-        "id": "G1201782029-NASA_MAAP",
-        "mode": "cmr",
-        "test_links": None,
-        "reverse_coords": None,
-        "asset_name": "data",
-        "asset_roles": ["data"],
-        "asset_media_type": "application/x-hdf5",
+        "collection": "NISAR",
+        "stactools-package": "git+https://github.com/MAAP-Project/nisar-sim.git@feat/nisar-sim-stactools::stactools.nisar_sim.stac",
+        "source":"tests/data-files/winnip_31604_12061_004_120717_L090_CX_07",
+        "dither": "X"
     }
+
     print(json.dumps(handler(sample_event, {}), indent=2))

--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -56,8 +56,9 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
     """
 
-    if "stactools-package" in event:
+    if "stactools-module" in event:
         module_str = event.pop("stactools-module")
+        assert module_str in AVAILABLE_STACTOOLS_MODULES
         stac_module = importlib.import_module(f'stactools.{module_str}.stac')
         stac_item = stac_module.create_item(event)
     else:
@@ -80,6 +81,7 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 
 if __name__ == "__main__":
+    
     # sample_event = {
     #     "collection": "GEDI02_A",
     #     "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/GEDI02_A___002/2020.12.31/GEDI02_A_2020366232302_O11636_02_T08595_02_003_02_V002.h5",
@@ -95,7 +97,7 @@ if __name__ == "__main__":
 
     sample_event = {
         "collection": "NISAR",
-        "stactools-package": "nisar_sim",
+        "stactools-module": "nisar_sim",
         "source":"tests/data-files/winnip_31604_12061_004_120717_L090_CX_07",
         "dither": "X"
     }

--- a/lambdas/build-stac/requirements.txt
+++ b/lambdas/build-stac/requirements.txt
@@ -9,3 +9,4 @@ shapely
 smart-open
 pydantic==1.9.1
 geojson==2.5.0
+git+https://github.com/MAAP-Project/nisar-sim.git@26dd4bb1f25180093551f63d00162891a4abe5bc

--- a/lambdas/build-stac/utils/regex.py
+++ b/lambdas/build-stac/utils/regex.py
@@ -42,7 +42,7 @@ def extract_dates(
 
     # Find dates in filename
     dates = []
-    for (pattern, dateformat) in DATE_REGEX_STRATEGIES:
+    for pattern, dateformat in DATE_REGEX_STRATEGIES:
         dates_found = re.compile(pattern).findall(filename)
         if not dates_found:
             continue

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -196,7 +196,7 @@ def gen_asset(role: str, link: dict, item: dict) -> pystac.Asset:
     # Fallback to asset_media_type defined in the item
     if asset_media_type == None and role == "data":
         asset_media_type = item.asset_media_type
-        
+
     return pystac.Asset(
         roles=[role], href=link.get("href"), media_type=asset_media_type
     )


### PR DESCRIPTION
Links to https://github.com/NASA-IMPACT/active-maap-sprint/issues/458. Currently waiting for https://github.com/NASA-IMPACT/active-maap-sprint/issues/456 to finish this draft, but this is the idea: 

- rely on `subprocess` and `importlib` to dynamically install and import a user provided stactools-compliant package. 
- call that package's `create_item` method with whatever arguments the user provides in the `event`. 
