### PR TITLE
feat: multiple data files

### DIFF
--- a/lambdas/build-stac/utils/events.py
+++ b/lambdas/build-stac/utils/events.py
@@ -1,33 +1,37 @@
-from datetime import datetime
-from typing import Dict, List, Literal, Optional, Union
-from pathlib import Path
 import re
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
 import pystac
-
+from pydantic import BaseModel, Field
 
 INTERVAL = Literal["month", "year"]
 
 
-class BaseEvent(BaseModel, frozen=True):
+class BaseEvent(BaseModel, frozen=True, arbitrary_types_allowed=True):
     collection: str
     remote_fileurl: str
 
+    product_id: Optional[str] = None
     id_regex: Optional[str] = None
     asset_name: Optional[str] = None
     asset_roles: Optional[List[str]] = None
     asset_media_type: Optional[Union[str, pystac.MediaType]] = None
-    assets: Optional[List[Dict]] = None
+    assets: Optional[Dict[str, pystac.Asset]] = (None,)
     mode: Optional[str] = None
     test_links: Optional[bool] = False
     reverse_coords: Optional[bool]
 
     def item_id(self: "BaseEvent") -> str:
         if self.id_regex:
-            id_components = re.findall(self.id_regex, self.s3_filename)
+            id_components = re.findall(
+                self.id_regex, self.s3_filename
+            )  # TODO: s3_filename
             assert len(id_components) == 1
             id = "-".join(id_components[0])
+        elif self.product_id:
+            id = self.product_id
         else:
             id = Path(self.remote_fileurl).stem
         return id

--- a/lambdas/build-stac/utils/regex.py
+++ b/lambdas/build-stac/utils/regex.py
@@ -1,10 +1,10 @@
 import re
-from typing import Callable, Dict, Tuple, Union
 from datetime import datetime, timezone
+from typing import Callable, Dict, Tuple, Union
+
 from dateutil.relativedelta import relativedelta
 
 from . import events
-
 
 DATERANGE = Tuple[datetime, datetime]
 

--- a/lambdas/cmr-query/handler.py
+++ b/lambdas/cmr-query/handler.py
@@ -4,7 +4,57 @@ import json
 import datetime as dt
 
 import requests
+from typing import Any, Dict, List
+import pystac
 
+def multi_asset_items(
+    data_file: str,
+    data_file_regex: str,
+    data: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """
+        Returns a list of file_obj's with the added "assets" key:value where "assets"
+        is a Dict[str, pystac.Asset] used to add item assets to a STAC item
+
+        Parameters:
+            data_file: str
+                string value describing the data file from which to build the STAC item
+            data_file_regex: str
+                string value becomes a regex pattern to find all related data file urls,
+                commonly a product ID or other identifier shared amongst product files
+            data: Dict[str, Any]
+                dictionary of file_obj's generated from querying CMR
+        Return:
+            objects: List[Dict[str, Any]]
+                modified dictionary of passed in file_obj's, used to generate STAC items
+    """
+    fileurls_pattern = re.compile(data_file_regex)
+    objects = []
+    product_ids = {}
+    
+    def _get_asset_name(remote_fileurl: str, product_id: str) -> str:
+        return re.sub(f".*{product_id}[-_]?", "", remote_fileurl)
+
+    # Creates a Dict[product_id, Dict[file_name, List[pystac.Asset]]]
+    for item in data:
+        match = re.search(fileurls_pattern, item["remote_fileurl"])
+        if match:
+            product_id = match.group()
+            product_ids[product_id] = product_ids.get(product_id, {})
+
+            product_ids[product_id][_get_asset_name(item["remote_fileurl"], product_id)] = pystac.Asset(
+                href=item["remote_fileurl"],
+                roles=["data"],
+            )
+
+    # Creates an objects Dict of modified file_obj's, adding file_obj["assets"]
+    for product_id in product_ids.keys():
+        for file_obj in data:
+            if re.search(f".*{product_id}.*{data_file}", file_obj["remote_fileurl"]):
+                file_obj["assets"] = product_ids[product_id]
+                objects.append(file_obj)
+
+    return objects
 
 def get_cmr_granules_endpoint(event):
     default_cmr_api_url = (
@@ -82,12 +132,21 @@ def handler(event, context):
                             file_obj[key] = value
         granules_to_insert.append(file_obj)
 
+    if event.get("data_file_regex"):
+        output = multi_asset_items(
+            data_file=event.get("data_file"),
+            data_file_regex=event.get("data_file_regex"),
+            data=granules_to_insert
+        )
+    else:
+        output = granules_to_insert
+
     # Useful for testing locally with build-stac/handler.py
     print(json.dumps(granules_to_insert[0], indent=2))
     return_obj = {
         **event,
         "cogify": event.get("cogify", False),
-        "objects": granules_to_insert,
+        "objects": output,
     }
     return return_obj
 
@@ -95,14 +154,16 @@ def handler(event, context):
 if __name__ == "__main__":
     sample_event = {
         "queue_messages": "true",
-        "collection": "GEDI02_A",
-        "version": "002",
+        "collection": "AfriSAR_UAVSAR_Ungeocoded_Covariance",
+        "version": "1",
         "discovery": "cmr",
-        "temporal": ["2019-04-01T00:00:00Z", "2019-07-31T23:59:59Z"],
+        "temporal": ["2016-03-08T00:00:00Z", "2016-03-08T00:00:00Z"],
         "mode": "cmr",
         "asset_name": "data",
         "asset_roles": ["data"],
-        "asset_media_type": "application/x-hdf5",
+        "asset_media_type": "application/x-hdr",
+        "data_file": "cov_1-1.hdr",
+        "data_file_regex": "uavsar_AfriSAR_v1-.*_\d{5}_\d{5}_\d{3}_\d{3}_\d{6}"
     }
 
     handler(sample_event, {})

--- a/lambdas/cmr-query/handler.py
+++ b/lambdas/cmr-query/handler.py
@@ -1,37 +1,36 @@
+import datetime as dt
+import json
 import os
 import re
-import json
-import datetime as dt
-
-import requests
 from typing import Any, Dict, List
+
 import pystac
+import requests
+
 
 def multi_asset_items(
-    data_file: str,
-    data_file_regex: str,
-    data: Dict[str, Any]
+    data_file: str, data_file_regex: str, data: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
     """
-        Returns a list of file_obj's with the added "assets" key:value where "assets"
-        is a Dict[str, pystac.Asset] used to add item assets to a STAC item
+    Returns a list of file_obj's with the added "assets" key:value where "assets"
+    is a Dict[str, pystac.Asset] used to add item assets to a STAC item
 
-        Parameters:
-            data_file: str
-                string value describing the data file from which to build the STAC item
-            data_file_regex: str
-                string value becomes a regex pattern to find all related data file urls,
-                commonly a product ID or other identifier shared amongst product files
-            data: Dict[str, Any]
-                dictionary of file_obj's generated from querying CMR
-        Return:
-            objects: List[Dict[str, Any]]
-                modified dictionary of passed in file_obj's, used to generate STAC items
+    Parameters:
+        data_file: str
+            string value describing the data file from which to build the STAC item
+        data_file_regex: str
+            string value becomes a regex pattern to find all related data file urls,
+            commonly a product ID or other identifier shared amongst product files
+        data: Dict[str, Any]
+            dictionary of file_obj's generated from querying CMR
+    Return:
+        objects: List[Dict[str, Any]]
+            modified dictionary of passed in file_obj's, used to generate STAC items
     """
     fileurls_pattern = re.compile(data_file_regex)
     objects = []
     product_ids = {}
-    
+
     def _get_asset_name(remote_fileurl: str, product_id: str) -> str:
         return re.sub(f".*{product_id}[-_]?", "", remote_fileurl)
 
@@ -42,7 +41,9 @@ def multi_asset_items(
             product_id = match.group()
             product_ids[product_id] = product_ids.get(product_id, {})
 
-            product_ids[product_id][_get_asset_name(item["remote_fileurl"], product_id)] = pystac.Asset(
+            product_ids[product_id][
+                _get_asset_name(item["remote_fileurl"], product_id)
+            ] = pystac.Asset(
                 href=item["remote_fileurl"],
                 roles=["data"],
             )
@@ -55,6 +56,7 @@ def multi_asset_items(
                 objects.append(file_obj)
 
     return objects
+
 
 def get_cmr_granules_endpoint(event):
     default_cmr_api_url = (
@@ -136,7 +138,7 @@ def handler(event, context):
         output = multi_asset_items(
             data_file=event.get("data_file"),
             data_file_regex=event.get("data_file_regex"),
-            data=granules_to_insert
+            data=granules_to_insert,
         )
     else:
         output = granules_to_insert
@@ -163,7 +165,7 @@ if __name__ == "__main__":
         "asset_roles": ["data"],
         "asset_media_type": "application/x-hdr",
         "data_file": "cov_1-1.hdr",
-        "data_file_regex": "uavsar_AfriSAR_v1-.*_\d{5}_\d{5}_\d{3}_\d{3}_\d{6}"
+        "data_file_regex": "uavsar_AfriSAR_v1-.*_\d{5}_\d{5}_\d{3}_\d{3}_\d{6}",
     }
 
     handler(sample_event, {})


### PR DESCRIPTION
Adds the ability to create STAC records from CMR collections containing granules with multiple data files.
- Isn't able to satisfy every single collection for every single granule file, some collections will have straggler files e.g ([.rdr files](https://search.maap-project.org/search/granules?p=C1200000308-NASA_MAAP&pg[0][id]=uavsar_AfriSAR_v1_SLC*.rdr&q=AfriSAR_UAVSAR_Coreg_SLC&m=0.0703125!-0.0703125!2!1!0!0%2C2&tl=1664910719!4!!))
- Matches most cases where granules contain files in a {product_id}_{data_file}.{ext} pattern