### PR TITLE
add collection name + timestap in publication pipeline statemachine name

### DIFF
--- a/scripts/item.py
+++ b/scripts/item.py
@@ -2,7 +2,7 @@ import json
 import boto3
 
 from dotenv import load_dotenv
-from .utils import args_handler, get_items, get_sf_ingestion_arn
+from .utils import args_handler, get_items, get_sf_ingestion_arn, get_collection_statemachine_name
 
 
 def insert_items(files):
@@ -15,9 +15,13 @@ def insert_items(files):
 
         sf_client = boto3.client("stepfunctions")
         sf_arn = get_sf_ingestion_arn()
+        
+        for event in events:
+            assert 'collection' in event 
+        
         for event in events:
             response = sf_client.start_execution(
-                stateMachineArn=sf_arn, input=json.dumps(event)
+                stateMachineArn=sf_arn, input=json.dumps(event), name=get_collection_statemachine_name(event['collection'])
             )
             print(response)
 

--- a/scripts/item.py
+++ b/scripts/item.py
@@ -2,7 +2,12 @@ import json
 import boto3
 
 from dotenv import load_dotenv
-from .utils import args_handler, get_items, get_sf_ingestion_arn, get_collection_statemachine_name
+from .utils import (
+    args_handler,
+    get_items,
+    get_sf_ingestion_arn,
+    get_collection_statemachine_name,
+)
 
 
 def insert_items(files):
@@ -15,13 +20,15 @@ def insert_items(files):
 
         sf_client = boto3.client("stepfunctions")
         sf_arn = get_sf_ingestion_arn()
-        
+
         for event in events:
-            assert 'collection' in event 
-        
+            assert "collection" in event
+
         for event in events:
             response = sf_client.start_execution(
-                stateMachineArn=sf_arn, input=json.dumps(event), name=get_collection_statemachine_name(event['collection'])
+                stateMachineArn=sf_arn,
+                input=json.dumps(event),
+                name=get_collection_statemachine_name(event["collection"]),
             )
             print(response)
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -4,7 +4,7 @@ import glob
 import os
 import base64
 import json
-
+import datetime
 import boto3
 
 DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "data")
@@ -77,3 +77,8 @@ def get_sf_ingestion_arn():
     APP_NAME = os.environ.get("APP_NAME")
     ENV = os.environ.get("ENV", "dev")
     return f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{APP_NAME}-{ENV}-stepfunction-discover"
+
+def get_collection_statemachine_name(collection: str) -> str:
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    return f'{collection}-{timestamp}'

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -78,7 +78,7 @@ def get_sf_ingestion_arn():
     ENV = os.environ.get("ENV", "dev")
     return f"arn:aws:states:{REGION}:{ACCOUNT_ID}:stateMachine:{APP_NAME}-{ENV}-stepfunction-discover"
 
-def get_collection_statemachine_name(collection: str) -> str:
 
+def get_collection_statemachine_name(collection: str) -> str:
     timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    return f'{collection}-{timestamp}'
+    return f"{collection}-{timestamp}"


### PR DESCRIPTION
when we run `insert-item` the `stateMachine` should now be named like `{collection_name}-{YYYMMDDHHmmSS}`.

https://github.com/NASA-IMPACT/active-maap-sprint/issues/504