### PR TITLE
fix: item assets

### DIFF
--- a/lambdas/build-stac/tests/test_cmr.py
+++ b/lambdas/build-stac/tests/test_cmr.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
-from utils.stac import generate_stac_cmrevent, from_cmr_links
+
+from utils.stac import from_cmr_links, generate_stac_cmrevent
 
 
 def test_generate_stac_cmrevent(

--- a/lambdas/build-stac/tests/test_cmr.py
+++ b/lambdas/build-stac/tests/test_cmr.py
@@ -5,19 +5,25 @@ from utils.stac import generate_stac_cmrevent, from_cmr_links
 def test_generate_stac_cmrevent(
     cmr_json_example, sample_assets, cmr_multi_asset_sample_event
 ):
-    with patch("utils.stac.GranuleQuery.get") as mock_get:
+    with patch("os.environ.get") as mock_os_environ_get, patch(
+        "utils.role.assume_role"
+    ) as mock_role_assume_role, patch("utils.stac.GranuleQuery.get") as mock_get, patch(
+        "utils.stac.from_cmr_links"
+    ) as mock_get_assets:
+        mock_os_environ_get.return_value = "my_role_arn"
+        mock_role_assume_role.return_value = {
+            "AccessKeyId": "my_access_key_id",
+            "SecretAccessKey": "my_secret_access_key",
+            "SessionToken": "my_session_token",
+        }
         mock_get.return_value = [cmr_json_example]
-        with patch("utils.stac.from_cmr_links") as mock_get_assets:
-            mock_get_assets.return_value = (
-                [],
-                sample_assets,
-            )  # empty links list for the puprpose of testing generate_stac_cmr_event
-            result = generate_stac_cmrevent(cmr_multi_asset_sample_event)
-            assert len(result.assets) == 3
-            assert (
-                result.id
-                == "uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz"
-            )
+        mock_get_assets.return_value = ([], sample_assets)
+        result = generate_stac_cmrevent(cmr_multi_asset_sample_event)
+        assert len(result.assets) == 3
+        assert (
+            result.id
+            == "uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz"
+        )
 
 
 def test_from_cmr_links(cmr_json_example, cmr_multi_asset_sample_event):

--- a/lambdas/build-stac/tests/test_cmr.py
+++ b/lambdas/build-stac/tests/test_cmr.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
-
-import pytest
-from utils.stac import generate_stac_cmrevent
+from utils.stac import generate_stac_cmrevent, from_cmr_links
 
 
 def test_generate_stac_cmrevent(
@@ -9,12 +7,26 @@ def test_generate_stac_cmrevent(
 ):
     with patch("utils.stac.GranuleQuery.get") as mock_get:
         mock_get.return_value = [cmr_json_example]
-        with patch("utils.stac.get_assets_from_cmr") as mock_get_assets:
-            mock_get_assets.return_value = sample_assets
+        with patch("utils.stac.from_cmr_links") as mock_get_assets:
+            mock_get_assets.return_value = (
+                [],
+                sample_assets,
+            )  # empty links list for the puprpose of testing generate_stac_cmr_event
             result = generate_stac_cmrevent(cmr_multi_asset_sample_event)
-
             assert len(result.assets) == 3
             assert (
                 result.id
                 == "uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz"
             )
+
+
+def test_from_cmr_links(cmr_json_example, cmr_multi_asset_sample_event):
+    with patch("utils.stac.generate_asset") as mock_generate_asset:
+        mock_generate_asset.return_value = "mocked_asset"
+        with patch("utils.stac.generate_link") as mock_generate_link:
+            mock_generate_link.return_value = "mocked_link"
+            links, assets = from_cmr_links(
+                cmr_json_example["links"], cmr_multi_asset_sample_event
+            )
+            assert len(links) == 1
+            assert len(assets) == 3

--- a/lambdas/build-stac/utils/events.py
+++ b/lambdas/build-stac/utils/events.py
@@ -16,7 +16,7 @@ class BaseEvent(BaseModel, frozen=True, arbitrary_types_allowed=True):
     product_id: Optional[str] = None
     id_regex: Optional[str] = None
     asset_name: Optional[str] = None
-    asset_roles: Optional[List[str]] = None
+    asset_roles: Optional[Union[Dict[str, List[str]], List[str]]] = None
     asset_media_type: Optional[Union[str, dict, pystac.MediaType]] = None
     assets: Optional[Dict[str, str]] = None
     mode: Optional[str] = None

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -2,7 +2,7 @@ import json
 import os
 from functools import singledispatch
 from pathlib import Path
-from typing import Union, Tuple, List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import geojson
 import pystac

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -45,7 +45,7 @@ def create_item(
             collection=collection,
             bbox=bbox,
         )
-        stac_item.links.extend(links) 
+        stac_item.links.extend(links)
         stac_item.assets = assets
         return stac_item
 

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -2,7 +2,7 @@ import json
 import os
 from functools import singledispatch
 from pathlib import Path
-from typing import Union
+from typing import Union, Tuple, List, Dict, Any, Optional
 
 import geojson
 import pystac
@@ -19,6 +19,7 @@ from . import events, regex, role
 def create_item(
     id,
     properties,
+    links,
     datetime,
     item_url,
     collection,
@@ -44,6 +45,7 @@ def create_item(
             collection=collection,
             bbox=bbox,
         )
+        stac_item.links.extend(links) 
         stac_item.assets = assets
         return stac_item
 
@@ -163,17 +165,17 @@ def get_bbox(coord_list) -> list[float]:
     return ret
 
 
-def generate_geometry_from_cmr(cmr_json, item) -> dict:
+def generate_geometry_from_cmr(polygons, boxes, reverse_coords) -> dict:
     """
     Generates geoJSON object from list of coordinates provided in CMR JSON
     """
     str_coords = None
-    if cmr_json.get("polygons"):
-        str_coords = cmr_json["polygons"][0][0].split()
-        if item.reverse_coords:
+    if polygons:
+        str_coords = polygons[0][0].split()
+        if reverse_coords:
             str_coords.reverse()
-    elif cmr_json.get("boxes"):
-        str_coords = cmr_json["boxes"][0].split()
+    elif boxes:
+        str_coords = boxes[0].split()
 
     if str_coords:
         polygon_coords = [(float(x), float(y)) for x, y in pairwise(str_coords)]
@@ -189,77 +191,106 @@ def generate_geometry_from_cmr(cmr_json, item) -> dict:
 def _content_type(link: str, asset_media_type: Union[str, dict]) -> str:
     if isinstance(asset_media_type, dict):
         file = Path(link)
-        return asset_media_type.get(file.suffix, asset_media_type.get(file.suffix[1:]))
+        return asset_media_type.get(
+            file.suffix, asset_media_type.get(file.suffix[1:], None)
+        )
     else:
         return asset_media_type
 
 
-def gen_asset(role: str, link: dict, item: dict) -> pystac.Asset:
-    if item.test_links and "http" in link.get("href"):
+def _roles(link: str, asset_roles: Union[list, dict], default: List[str]) -> List[str]:
+    if isinstance(asset_roles, dict):
+        file = Path(link)
+        return asset_roles.get(file.suffix, asset_roles.get(file.suffix[1:], default))
+    else:
+        return asset_roles
+
+
+def generate_asset(
+    roles: Union[str, Dict[str, List[str]]], link: dict, item: dict
+) -> pystac.Asset:
+    href = link.get("href")
+    if item.test_links and "http" in href:
         try:
-            requests.head(link.get("href"))
+            requests.head(href)
         except Exception as e:
             print(f"Caught error for link {link}: {e}")
             return None
-    asset_media_type = link.get("type")
-    # Fallback to asset_media_type defined in the item
-    if asset_media_type == None and role == "data":
-        asset_media_type = item.asset_media_type
 
-    return pystac.Asset(
-        roles=[role], href=link.get("href"), media_type=asset_media_type
+    # If type is in CMR link{} use that, else use the type from the asset_media_type
+    asset_media_type = link.get("type", _content_type(href, item.asset_media_type))
+    asset_roles = _roles(href, item.asset_roles, ["data"])
+
+    return pystac.Asset(roles=asset_roles, href=href, media_type=asset_media_type)
+
+
+def generate_link(
+    rel: Union[str, pystac.RelType],
+    target: Union[str, pystac.STACObject],
+    media_type: Optional[str] = None,
+    title: Optional[str] = None,
+    extra_fields: Optional[Dict[str, Any]] = None,
+) -> pystac.Link:
+    """
+    Generate a link object from a rel, target, media type, title, and extra fields.
+    """
+    return pystac.Link(
+        rel=rel,
+        target=target,
+        media_type=media_type,
+        title=title,
+        extra_fields=extra_fields,
     )
 
 
-def get_assets_from_cmr(cmr_json, item) -> dict[pystac.Asset]:
+def from_cmr_links(cmr_links, item) -> Tuple[List, Dict[str, pystac.Asset]]:
     """
     Generates a dictionary of pystac.Asset's from cmr_json links
-    TODO(aimee): This is using some heuristics and could probably be refined according to some standard in the future.
     """
     assets = {}
-    links = cmr_json["links"]
-    for link in links:
-        if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/data#":
+    links = []
+    for link in cmr_links:
+        if link["rel"].endswith("data#"):
             extension = os.path.splitext(link["href"])[-1].replace(".", "")
             if extension == "prj":
-                asset = gen_asset("metadata", link, item)
-                if asset:
-                    assets["metadata"] = asset
-            asset = gen_asset("data", link, item)
+                links.append(
+                    generate_link(
+                        "metadata", link["href"], link.get("type"), link.get("title")
+                    )
+                )
+            asset = generate_asset(item.asset_roles, link, item)
             if asset and "data" not in assets:
                 assets["data"] = asset
-        if link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/s3#":
-            asset = gen_asset("data", link, item)
+        if link["rel"].endswith("s3#"):
+            asset = generate_asset(item.asset_roles, link, item)
             if asset:
                 assets["data"] = asset
-        if (
-            link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/metadata#"
-            and "metadata" not in assets
-        ):
-            asset = gen_asset("metadata", link, item)
-            if asset:
-                assets["metadata"] = asset
-        if (
-            link["rel"] == "http://esipfed.org/ns/fedsearch/1.1/documentation#"
-            and "documentation" not in assets
-        ):
-            asset = gen_asset("documentation", link, item)
-            if asset:
-                assets["documentation"] = asset
+        if link["rel"].endswith("metadata#"):
+            links.append(
+                generate_link(
+                    "metadata", link["href"], link.get("type"), link.get("title")
+                )
+            )
+        if link["rel"].endswith("documentation#"):
+            links.append(
+                generate_link(
+                    "documentation", link["href"], link.get("type"), link.get("title")
+                )
+            )
 
     if item.assets:
+        # Removes the default data asset, exists as a duplicate
         del assets["data"]
-        # Quick fix for failing item ingest
-        if assets.get("documentation"):
-            del assets["documentation"]
+
         pystac_asset = lambda link: pystac.Asset(
-            roles=["data"],
+            roles=_roles(link, item.asset_roles, ["data"]),
             href=link,
             media_type=_content_type(link, item.asset_media_type),
         )
         pystac_assets = {key: pystac_asset(value) for key, value in item.assets.items()}
-        return dict(sorted({**pystac_assets, **assets}.items()))
-    return assets
+        return links, dict(sorted({**pystac_assets, **assets}.items()))
+
+    return links, assets
 
 
 def cmr_api_url() -> str:
@@ -273,31 +304,35 @@ def cmr_api_url() -> str:
 @generate_stac.register
 def generate_stac_cmrevent(item: events.CmrEvent) -> pystac.Item:
     """
-    Generate STAC Item from CMR granule
+    Generates a STAC Item from a CmrEvent
     """
-    cmr_json = (
+    properties = (
         GranuleQuery(mode=f"{cmr_api_url()}/search/")
         .concept_id(item.granule_id)
         .get(1)[0]
     )
-    cmr_json["concept_id"] = cmr_json.pop("id")
+    properties["concept_id"] = properties.pop("id")
+    del properties["title"]  # Remove title from properties, it's already in the item
 
-    if item.product_id:
-        cmr_json["title"] = item.product_id
+    geometry = generate_geometry_from_cmr(
+        properties.pop("polygons", None),
+        properties.pop("boxes", None),
+        item.reverse_coords,
+    )
 
-    geometry = generate_geometry_from_cmr(cmr_json, item)
     if geometry:
         bbox = get_bbox(list(geojson.utils.coords(geometry["coordinates"])))
     else:
         bbox = None
 
-    assets = get_assets_from_cmr(cmr_json, item)
+    links, assets = from_cmr_links(properties.pop("links", None), item)
 
     return create_item(
         id=item.item_id(),
-        properties=cmr_json,
+        properties=properties,
+        links=links,
         mode=item.mode,
-        datetime=str_to_datetime(cmr_json["time_start"]),
+        datetime=str_to_datetime(properties["time_start"]),
         item_url=item.remote_fileurl,
         collection=item.collection,
         asset_name=item.asset_name,

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -207,7 +207,10 @@ def _roles(link: str, asset_roles: Union[list, dict], default: List[str]) -> Lis
 
 
 def generate_asset(
-    roles: Union[str, Dict[str, List[str]]], link: dict, item: dict
+    roles: Union[str, Dict[str, List[str]]],
+    link: dict,
+    item: dict,
+    default_role: str = ["data"],
 ) -> pystac.Asset:
     href = link.get("href")
     if item.test_links and "http" in href:
@@ -219,7 +222,7 @@ def generate_asset(
 
     # If type is in CMR link{} use that, else use the type from the asset_media_type
     asset_media_type = link.get("type", _content_type(href, item.asset_media_type))
-    asset_roles = _roles(href, item.asset_roles, ["data"])
+    asset_roles = _roles(href, roles, default_role)
 
     return pystac.Asset(roles=asset_roles, href=href, media_type=asset_media_type)
 
@@ -253,10 +256,8 @@ def from_cmr_links(cmr_links, item) -> Tuple[List, Dict[str, pystac.Asset]]:
         if link["rel"].endswith("data#"):
             extension = os.path.splitext(link["href"])[-1].replace(".", "")
             if extension == "prj":
-                links.append(
-                    generate_link(
-                        "metadata", link["href"], link.get("type"), link.get("title")
-                    )
+                asset = generate_asset(
+                    item.asset_roles, link, item, default_role=["metadata"]
                 )
             asset = generate_asset(item.asset_roles, link, item)
             if asset and "data" not in assets:


### PR DESCRIPTION
- Removes documentation and metadata links from item assets -> moves them into item links
- Removes duplicated properties, e.g boxes or title (was being set to item id)
- Adds method for custom asset roles based on file type, most useful for multi-data STAC records

*Also removed the entire cmr_json from being passed into functions